### PR TITLE
remove vs2015_runtime and vc requirements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,24 +51,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not win]
 
 requirements:
@@ -22,13 +22,11 @@ requirements:
     - setuptools
     - winpty
     - backports.shutil_which  # [py2k]
-    - vc 14
   run:
     - backports.shutil_which  # [py2k]
     - setuptools  # [py2k]
     - python
     - winpty
-    - vs2015_runtime
 
 test:
   imports:
@@ -51,3 +49,4 @@ extra:
     - ccordoba12
     - andfoy
     - goanpeca
+    - jjhelmus


### PR DESCRIPTION
Remove vs2015_runtime requirement.  Package can be build with VS 2008 provided
a winpty package is available which support this runtime, such as one compiled
using the m2w64 toolchain.