### PR TITLE
use m2w64-toolchain for all builds

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,4 @@
 if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if "%ARCH%" == "32" (set MACRO=MS_WIN32) else (set PLATFORM=MS_WIN64)
+"%PYTHON%" setup.py install -D "%MACRO"--single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,3 @@
 if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
-call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
-set DISTUTILS_USE_SDK=1
-set MSSdk=1
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,3 @@
 if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
-if "%ARCH%" == "32" (set MACRO=MS_WIN32) else (set PLATFORM=MS_WIN64)
-"%PYTHON%" setup.py install -D "%MACRO"--single-version-externally-managed --record record.txt
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,16 +22,15 @@ requirements:
     - setuptools
     - winpty
     - backports.shutil_which  # [py2k]
-    # use the m2w64 toolchain for Python 2.7 as VS 2008 is not supported
-    - m2w64-toolchain         # [py2k]
-    - libpython               # [py2k]
+    # use the m2w64 toolchain for all builds
+    - m2w64-toolchain
+    - libpython
   run:
     - backports.shutil_which  # [py2k]
     - setuptools  # [py2k]
     - python
     - winpty
-    # the gcc libraries are only needed on win-32
-    - m2w64-gcc-libs          # [py2k and win32]
+    - m2w64-gcc-libs
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not win]
 
 requirements:
@@ -22,11 +22,16 @@ requirements:
     - setuptools
     - winpty
     - backports.shutil_which  # [py2k]
+    # use the m2w64 toolchain for Python 2.7 as VS 2008 is not supported
+    - m2w64-toolchain         # [py2k]
+    - libpython               # [py2k]
   run:
     - backports.shutil_which  # [py2k]
     - setuptools  # [py2k]
     - python
     - winpty
+    # the gcc libraries are only needed on win-32
+    - m2w64-gcc-libs          # [py2k and win32]
 
 test:
   imports:


### PR DESCRIPTION
Use the m2w64 toolchain to compile the extension on Python 2.7 as VS 2008 is
not supported by winpty